### PR TITLE
WoE reclassify crash

### DIFF
--- a/core/libs/Management/LayerManagement.py
+++ b/core/libs/Management/LayerManagement.py
@@ -32,7 +32,7 @@ class LayerManagement:
         '''
         Return the pixmap item object by name
         '''
-        for key, values in self.canvasContent.iteritems():
+        for key, values in self.canvasContent.items():
             if values['Name'] == name:
                 return key
 
@@ -40,7 +40,7 @@ class LayerManagement:
         '''
         Return the tree widget item object by name
         '''
-        for key, values in self.treeContent.iteritems():
+        for key, values in self.treeContent.items():
             if values['Name'] == name:
                 return key
 
@@ -63,3 +63,10 @@ class LayerManagement:
         except BaseException:
             sourcePath = self.treeContent[item]['Source']
         return sourcePath
+
+    def removeTreeItemByName(self, name: str) -> None:
+        '''
+        Removes an item from the tree based on its name.
+        '''
+        key = self.getTreeItemByName(name)
+        self.treeContent.pop(key)

--- a/core/widgets/WofE/wofeBatch_main_thread.py
+++ b/core/widgets/WofE/wofeBatch_main_thread.py
@@ -197,6 +197,10 @@ class WofETool(QMainWindow):
             root = self.tree.invisibleRootItem()
             index = self.tree.currentIndex().row()
             treeItem = self.tree.topLevelItem(index)
+            # remove from LM
+            layerName = treeItem.text(0)
+            self.LM.removeTreeItemByName(layerName)
+            # remove from visibile treeWidget
             root.removeChild(treeItem)
 
     @pyqtSlot()
@@ -349,7 +353,7 @@ class WofETool(QMainWindow):
 
         # Check if the training feature combo box is not empty path and return a
         # message if path is not set
-        if str(self.ui.trainingFeatureComboBox.currentText()) == "":
+        if not os.path.isfile(self.ui.trainingFeatureComboBox.currentText()):
             QMessageBox.warning(self, self.tr("Inventory missing!"), self.tr(
                 "Select the inventory dataset to be used as training data!"))
             return
@@ -626,7 +630,6 @@ class Worker(QObject):
                         str(rasterPath), os.path.join(
                             self.workspace, "land_rast.tif"), self.rasterMethod)
 
-                    eventRaster = Raster(eventRasterPath)
                     eventRaster = Raster(eventRasterPath)
 
                     wofe = WofE(raster, eventRaster, "")  # Weight Calculation


### PR DESCRIPTION
Fixes a bug where LSAT could crash if the user modified the WoE Inputs after a first calculation.