### PR TITLE
Warn User if landslide size >= region size

### DIFF
--- a/core/libs/Analysis/BivariateSolver.py
+++ b/core/libs/Analysis/BivariateSolver.py
@@ -128,10 +128,7 @@ class WofE:
         area_total = self.table['Class'].sum()
 
         stable_area = area_total - landsl_total
-        try:
-            prior = (float(landsl_total) / float(area_total)) / (float(stable_area) / float(area_total))
-        except ZeroDivisionError: # stable_area == 0
-            return self.table
+        prior = (float(landsl_total) / float(area_total)) / (float(stable_area) / float(area_total))
         variance_prior = 1 / float(landsl_total)
 
         # Compute self.table values

--- a/core/libs/Analysis/BivariateSolver.py
+++ b/core/libs/Analysis/BivariateSolver.py
@@ -128,7 +128,10 @@ class WofE:
         area_total = self.table['Class'].sum()
 
         stable_area = area_total - landsl_total
-        prior = (float(landsl_total) / float(area_total)) / (float(stable_area) / float(area_total))
+        try:
+            prior = (float(landsl_total) / float(area_total)) / (float(stable_area) / float(area_total))
+        except ZeroDivisionError: # stable_area == 0
+            return self.table
         variance_prior = 1 / float(landsl_total)
 
         # Compute self.table values


### PR DESCRIPTION
All data based analysis methods will crash if there is no stable area. 
We now warn the user during import if atleast one landslide is larger than the region.
In the future we could check for more (e.g. atleast one landslide in region).