### PR TITLE
bug fixes

### DIFF
--- a/core/widgets/ImportData/importData_importRaster.py
+++ b/core/widgets/ImportData/importData_importRaster.py
@@ -103,7 +103,7 @@ class ImportRaster(QObject):
             else:
                 rasterNoDataLocation = np.argwhere(rasterarray == raster.nodata)
         else:
-            rasterNoData = ((),()) # tuple of two empty tuples to indicate absence of NoData
+            rasterNoDataLocation = np.array(((), ()))  # tuple of two empty tuples to indicate absence of NoData
         maskarray = mask.getArrayFromBand()
         maskNoDataLocation = np.argwhere(maskarray == mask.nodata)
         if np.array_equal(rasterNoDataLocation, maskNoDataLocation):


### PR DESCRIPTION
Bug: Importing a raster crashed since `rasterNoDataLocation` is called before being assigned.

Summary:
I believe this is a bug in which `rasterNoData` wasn't properly renamed to `rasterNoDataLocation` (see existing lines 102 and 104). Also, the default value in the outer else statement cannot be a tuple of tuples, since we are always dealing with numPy arrays. So, I'm properly casting the tuples to NumpyArr so line 114 won't fail (rasterNoDataLocation.shape) since tuples don't have a `shape` property.

Changes:
- renamed unused variable `rasterNoData` to `rasterNoDataLocation` to fix refactor bug
- casting empty tuple to numPy array