### PR TITLE
Fixed Model Builder for Python >=3.13 

### DIFF
--- a/core/libs/Analysis/LogisticRegressionAnalysis.py
+++ b/core/libs/Analysis/LogisticRegressionAnalysis.py
@@ -46,8 +46,7 @@ class LogisticRegressionAnalysis(QObject):
     @pyqtSlot()
     def run(self):
         rpw = rasterprepwork()
-        stack, labels, stack_full, noDataArray, nr_of_unique_parameters = rasterprepwork.prepareInputData(
-            rpw, self.maskRaster, self.workspacePath, self.featurePath, self.data_list)
+        stack, labels, stack_full, noDataArray, nr_of_unique_parameters = rpw.prepareInputData(self.maskRaster, self.workspacePath, self.featurePath, self.data_list)
         self.loggingInfoSignal.emit(self.tr("Settings:") + str(self.settings))
         self.loggingInfoSignal.emit(self.tr("Start training..."))
         # Logistic regression with sklearn

--- a/core/widgets/ImportData/importData_importRaster.py
+++ b/core/widgets/ImportData/importData_importRaster.py
@@ -219,7 +219,7 @@ class ImportRaster(QObject):
         if os.path.isfile(newrasterpath):
             self.infoSignal.emit(
                 self.tr("{} already exists and will be overwritten.").format(newrasterpath))
-        newraster = gdal.GetDriverByName("Gtiff").Create(
+        newraster = gdal.GetDriverByName("GTiff").Create(
             newrasterpath, mask.cols, mask.rows, 1, datatype)
         # 1 is the number of bands
         newraster.SetGeoTransform(mask.geoTrans)
@@ -227,7 +227,7 @@ class ImportRaster(QObject):
         newraster.GetRasterBand(1).SetNoDataValue(mask.nodata)
         gdalraster = gdal.Open(raster.path, gdalconst.GA_ReadOnly)
         gdal.ReprojectImage(gdalraster, newraster, raster.proj, mask.proj, resamplingtypefunc)
-        newraster.FlushCache()
+        newraster = None
         self.updateNoDataValue(newrasterpath, mask)
         newraster = Raster(newrasterpath)
         self.checkRAT(raster, newraster)
@@ -243,7 +243,4 @@ class ImportRaster(QObject):
         maskarray = mask.getArrayFromBand()
         newrasterarray[maskarray == mask.nodata] = mask.nodata
         band.WriteArray(newrasterarray)
-        band.SetNoDataValue(mask.nodata)
-        band.ComputeStatistics(False)
-        dataset.FlushCache()
         self.infoSignal.emit(self.tr("NoData values updated."))

--- a/core/widgets/LogisticRegression/logisticRegression_main.py
+++ b/core/widgets/LogisticRegression/logisticRegression_main.py
@@ -287,7 +287,7 @@ class LogRegression(QMainWindow):
             self.progressBar.setRange(0, 0)
             self.featurePath = str(self.ui.landslideInventoryComboBox.currentText())
             name = self.ui.outputlineEdit.text()
-            self.data_list = []
+            data_list = []
             logging.info(self.tr("Start data preparation..."))
             self.root = self.tree.invisibleRootItem()
             for i in range(self.tree.topLevelItemCount()):
@@ -295,15 +295,12 @@ class LogRegression(QMainWindow):
                 rasterPath = self.LM.treeContent[hash(str(item))]['Source']
                 typeBox = self.tree.itemWidget(item, 1)
                 dataType = typeBox.currentText()
-
                 layerName = self.LM.treeContent[hash(str(item))]['Name']
-
-                locals()["dataset" + str(i)] = (rasterPath, dataType, layerName)
-                self.data_list.append(locals()["dataset" + str(i)])
+                data_list.append((rasterPath, dataType, layerName))
             settings = self.getArgsFromConfigFile()
 
             self.logisticRegAnalysis = LogisticRegressionAnalysis(
-                self.projectPath, self.data_list, self.featurePath, self.tablesPath, name, settings)
+                self.projectPath, data_list, self.featurePath, self.tablesPath, name, settings)
             self.thread = QThread()
             self.logisticRegAnalysis.moveToThread(self.thread)
             self.logisticRegAnalysis.doneSignal.connect(self.done)
@@ -325,7 +322,7 @@ class LogRegression(QMainWindow):
         :return: tuple args
         """
         self.config = configparser.ConfigParser()
-        self.config.read(os.path.join("core", "Widgets", "LogisticRegression", "configLogReg.ini"))
+        self.config.read(os.path.join("core", "widgets", "LogisticRegression", "configLogReg.ini"))
         penalty = str(self.config["USER_SETTINGS"]["penalty"])
         dual_str = self.config["USER_SETTINGS"]["dual"]
         if dual_str == "True":

--- a/core/widgets/LogisticRegression/logisticRegression_settings.py
+++ b/core/widgets/LogisticRegression/logisticRegression_settings.py
@@ -18,7 +18,7 @@ class Settings(QWidget):
         self.ui.setupUi(self)
         self.setAttribute(Qt.WA_QuitOnClose, False)
         self.configFilePath = os.path.join(
-            "core", "Widgets", "LogisticRegression", "configLogReg.ini")
+            "core", "widgets", "LogisticRegression", "configLogReg.ini")
         self.checkini()
         self.setWindowIcon(QIcon(':/icons/Icons/Settings.png'))
         self.setWindowTitle(self.tr("Advanced Settings"))

--- a/core/widgets/ModelBuilder/modelbuilder_calc.py
+++ b/core/widgets/ModelBuilder/modelbuilder_calc.py
@@ -2,6 +2,7 @@ import math
 import random
 import numpy as np
 import os, logging, traceback
+import sys
 from PyQt5.QtCore import *
 from sklearn.metrics import roc_curve, roc_auc_score
 from sklearn.metrics import auc as aucfunc
@@ -81,8 +82,8 @@ class ModelBuilder_calc(QObject):
         for rasterpath in rasterpathlist:
             layerName = os.path.splitext(os.path.basename(rasterpath))[0].replace(".", "").replace(" ","")
             raster = Raster(rasterpath)
-            locals()[layerName] = raster.getArrayFromBand().astype(np.float32)
-            locals()[layerName][locals()[layerName] == -9999] = np.nan
+            sys._getframe(0).f_locals[layerName] = raster.getArrayFromBand().astype(np.float32)
+            sys._getframe(0).f_locals[layerName][sys._getframe(0).f_locals[layerName] == -9999] = np.nan
         try:
             array = eval(expression)
             if not isinstance(array, np.ndarray):

--- a/core/widgets/ModelBuilder/modelbuilder_main.py
+++ b/core/widgets/ModelBuilder/modelbuilder_main.py
@@ -293,9 +293,13 @@ class ModelBuilder(QMainWindow):
         """
         if osname == "nt":  # Windows
             prop = matplotlib.font_manager.FontProperties(fname="C:\\Windows\\Fonts\\Msyh.ttc")
-        else:  # ubuntu
+        else: # we should just use some default font really.
+            if os.path.isfile("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"):  # ubuntu
+                fontPath = "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"
+            elif os.path.isfile("/usr/share/fonts/google-noto-vf/NotoSans[wght].ttf"): # fedora
+                fontPath = "/usr/share/fonts/google-noto-vf/NotoSans[wght].ttf"
             prop = matplotlib.font_manager.FontProperties(
-                fname="/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc")
+                fname=fontPath)
         return prop
 
     def loadfeaturefiles(self, projectpath):


### PR DESCRIPTION
I fixed the Model Builder for Python versions above 3.13.
We used locals() there to setup for eval().
locals() was changed in Python 3.13 (https://docs.python.org/3/whatsnew/3.13.html).
I am using sys there as a hacky workaround, because we use eval().

I also realized we use locals() for setting up Logistic Regression but that's not necessary so I removed it.
Additionally I made some changes to get it running on Fedora 42, i.e. capitalization changes.
The font thing is a workaround and we should matplotlib fonts because we can expect them to be there.

My pip freeze output:
```
$ pip freeze
branca==0.8.1
certifi==2025.8.3
charset-normalizer==3.4.3
contourpy==1.3.3
cycler==0.12.1
et_xmlfile==2.0.0
folium==0.20.0
fonttools==4.59.2
GDAL==3.10.3
idna==3.10
Jinja2==3.1.6
joblib==1.5.2
kiwisolver==1.4.9
lxml==6.0.1
MarkupSafe==3.0.2
matplotlib==3.10.6
numpy==2.3.2
openpyxl==3.1.5
packaging==25.0
pillow==11.3.0
pyparsing==3.2.3
PyQt5==5.15.11
PyQt5-Qt5==5.15.17
PyQt5_sip==12.17.0
python-dateutil==2.9.0.post0
python-docx==1.2.0
requests==2.32.5
scikit-learn==1.7.1
scipy==1.16.1
six==1.17.0
threadpoolctl==3.6.0
typing_extensions==4.15.0
urllib3==2.5.0
xyzservices==2025.4.0
```
